### PR TITLE
Add an option to discard the quotes around the arguments.

### DIFF
--- a/clyngor/answers.py
+++ b/clyngor/answers.py
@@ -177,7 +177,7 @@ class Answers:
                 if args:
                     args = args[1:-1]
                     if self._discard_quotes and not self._as_pyasp:
-                        args = utils.remove_quotes_arguments(args)
+                        args = utils.remove_arguments_quotes(args)
                     if not self._collapse_atoms:  # else: atom as string
                         # parse also integers, if asked to
                         args = tuple(

--- a/clyngor/answers.py
+++ b/clyngor/answers.py
@@ -155,6 +155,7 @@ class Answers:
             yield from parsing.Parser(
                 self._collapse_atoms, self._collapse_args,
                 self._discard_quotes and not self._atoms_as_string and not self._as_pyasp,
+                self._first_arg_only,
                 parse_integer=self._parse_int
             ).parse_terms(answer_set)
 
@@ -165,6 +166,10 @@ class Answers:
                     pred, args = match.groups()
                     if args is None:  # atom with no arg
                         args = ''
+                    elif self._first_arg_only:
+                        args = args.split(',')[0]
+                        if not args.endswith(')'):
+                            args = args + ')'
                     yield pred + args  # just send the match
                     continue
                 pred, args = match.groups()

--- a/clyngor/answers.py
+++ b/clyngor/answers.py
@@ -37,6 +37,8 @@ class Answers:
         self._group_atoms = False
         self._as_pyasp = False
         self._sorted = False
+        self._discard_quotes = False
+        # TODO: break api to add keep quotes instead of discard quotes.
         self._careful_parsing = False
         self._collapse_atoms= False
         self._collapse_args = True
@@ -77,6 +79,12 @@ class Answers:
     def sorted(self):
         """Sort the atom (or the args when grouped)"""
         self._sorted = True
+        return self
+
+    @property
+    def discard_quotes(self):
+        """Discard the quotes of the string"""
+        self._discard_quotes = True
         return self
 
     @property
@@ -141,8 +149,12 @@ class Answers:
         """Yield atoms as (pred, args) according to parsing options"""
         REG_ANSWER_SET = re.compile(r'([a-z][a-zA-Z0-9_]*)(\([^)]+\))?')
         if self._careful_parsing:
+            # _discard_quotes is incompatible with atoms_as_string and as_pyasp.
+            # atom_as_string: remove the quotes delimiting arguments.
+            # as_pyasp: remove the quotes for the arguments.
             yield from parsing.Parser(
                 self._collapse_atoms, self._collapse_args,
+                self._discard_quotes and not self._atoms_as_string and not self._as_pyasp,
                 parse_integer=self._parse_int
             ).parse_terms(answer_set)
 
@@ -159,6 +171,8 @@ class Answers:
                 assert args is None or (args.startswith('(') and args.endswith(')'))
                 if args:
                     args = args[1:-1]
+                    if self._discard_quotes and not self._as_pyasp:
+                        args = utils.remove_quotes_arguments(args)
                     if not self._collapse_atoms:  # else: atom as string
                         # parse also integers, if asked to
                         args = tuple(

--- a/clyngor/test/test_answers.py
+++ b/clyngor/test/test_answers.py
@@ -26,7 +26,7 @@ def quotes_answers():
 @pytest.fixture
 def complex_quotes_answers():
     return Answers((
-        'a("\"cou\"cou\"") b(""&"&"1234""&"")',
+        'a("\"cou\"cou\"") b(""&"&"1234""&"")',  # Random gibberish
     ))
 
 @pytest.fixture
@@ -149,6 +149,16 @@ def test_tunning_atoms_as_string_and_sorted_more_complex_careful_parsing(many_at
     answers = many_atoms_answers.atoms_as_string.sorted.first_arg_only.careful_parsing
     assert next(answers) == tuple(sorted('a b(4) b(3) a(1) vv(1) vv v(a) v(b)'.split()))
     assert next(answers, None) is None
+
+
+def test_first_arg_only():
+    answers = Answers(('p(1,2,3)',)).first_arg_only
+    assert next(answers) == {('p', 1)}
+
+
+def test_first_arg_only_with_careful_parsing():
+    answers = Answers(('p("1,5","2,456",3)',)).first_arg_only.careful_parsing
+    assert next(answers) == {('p', '"1,5"')}
 
 
 def test_tunning_atoms_as_string_and_sorted(simple_answers):

--- a/clyngor/test/test_answers.py
+++ b/clyngor/test/test_answers.py
@@ -85,9 +85,7 @@ def test_discard_quotes(quotes_answers):
     answers = quotes_answers.discard_quotes.by_predicate.first_arg_only
     assert next(answers) == {'a': frozenset({'c'}), 'b': frozenset({'d'})}
     answers = quotes_answers.discard_quotes.by_predicate.first_arg_only.atoms_as_string
-    assert next(answers) == {'a("c")', 'b("d","e")'}
-    # Above assert is not correct and will break if issue #8 is fixed.
-    # assert next(answers) == {'a("c")', 'b("d")'}
+    assert next(answers) == {'a("c")', 'b("d")'}
     assert next(answers, None) is None
 
 def test_discard_quotes_careful_parsing(quotes_answers):
@@ -100,9 +98,7 @@ def test_discard_quotes_careful_parsing(quotes_answers):
     answers = quotes_answers.discard_quotes.by_predicate.first_arg_only
     assert next(answers) == {'a': frozenset({'c'}), 'b': frozenset({'d'})}
     answers = quotes_answers.careful_parsing.discard_quotes.by_predicate.first_arg_only.atoms_as_string
-    assert next(answers) == {'a("c")', 'b("d","e")'}
-    # Above assert is not correct and will break if issue #8 is fixed.
-    # assert next(answers) == {'a("c")', 'b("d")'}
+    assert next(answers) == {'a("c")', 'b("d")'}
     assert next(answers, None) is None
 
 def test_discard_quotes_complex(complex_quotes_answers):
@@ -144,7 +140,13 @@ def test_tunning_first_arg_only(simple_answers):
 
 
 def test_tunning_atoms_as_string_and_sorted_more_complex(many_atoms_answers):
-    answers = many_atoms_answers.atoms_as_string.sorted
+    answers = many_atoms_answers.atoms_as_string.sorted.first_arg_only
+    assert next(answers) == tuple(sorted('a b(4) b(3) a(1) vv(1) vv v(a) v(b)'.split()))
+    assert next(answers, None) is None
+
+
+def test_tunning_atoms_as_string_and_sorted_more_complex_careful_parsing(many_atoms_answers):
+    answers = many_atoms_answers.atoms_as_string.sorted.first_arg_only.careful_parsing
     assert next(answers) == tuple(sorted('a b(4) b(3) a(1) vv(1) vv v(a) v(b)'.split()))
     assert next(answers, None) is None
 

--- a/clyngor/test/test_answers.py
+++ b/clyngor/test/test_answers.py
@@ -14,8 +14,25 @@ def simple_answers():
     ))
 
 @pytest.fixture
+def quotes_answers():
+    return Answers((
+        'a("c") b("d","e")',
+        'a("c") b("d","e")',
+        'a("c") b("d","e")',
+        'a("c") b("d","e")',
+        'a("c") b("d","e")',
+    ))
+
+@pytest.fixture
+def complex_quotes_answers():
+    return Answers((
+        'a("\"cou\"cou\"") b(""&"&"1234""&"")',
+    ))
+
+@pytest.fixture
 def multiple_args():
     return Answers((
+        'edge(4,"s…lp.") r_e_l(1,2)',
         'edge(4,"s…lp.") r_e_l(1,2)',
         'edge(4,"s…lp.") r_e_l(1,2)',
         'edge(4,"s…lp.") r_e_l(1,2)',
@@ -41,6 +58,7 @@ def many_atoms_answers():
 def optimized_answers():
     return Answers((
         ('edge(4,"s…lp.") r_e_l(1,2)', 1),
+        ('edge(4,"s…lp.") r_e_l(1,2)', 1),
         ('edge(4,"s…lp.") r_e_l(1,2)', 2),
         ('edge(4,"s…lp.") r_e_l(1,2)', 3),
         ('edge(4,"s…lp.") r_e_l(1,2)', 4),
@@ -57,6 +75,40 @@ def test_parsing_args_when_noargs(noarg_answers):
     assert next(answers) == {'d': frozenset({()}), 'e': frozenset({()}),
                              'f': frozenset({()})}
 
+def test_discard_quotes(quotes_answers):
+    answers = quotes_answers
+    assert next(answers) == {('a', ('"c"',)), ('b', ('"d"','"e"',))}
+    answers = quotes_answers.discard_quotes
+    assert next(answers) == {('a', ('c',)), ('b', ('d','e',))}
+    answers = quotes_answers.discard_quotes.by_predicate
+    assert next(answers) == {'a': frozenset({('c',)}), 'b': frozenset({('d', 'e')})}
+    answers = quotes_answers.discard_quotes.by_predicate.first_arg_only
+    assert next(answers) == {'a': frozenset({'c'}), 'b': frozenset({'d'})}
+    answers = quotes_answers.discard_quotes.by_predicate.first_arg_only.atoms_as_string
+    assert next(answers) == {'a("c")', 'b("d","e")'}
+    # Above assert is not correct and will break if issue #8 is fixed.
+    # assert next(answers) == {'a("c")', 'b("d")'}
+    assert next(answers, None) is None
+
+def test_discard_quotes_careful_parsing(quotes_answers):
+    answers = quotes_answers.careful_parsing
+    assert next(answers) == {('a', ('"c"',)), ('b', ('"d"','"e"',))}
+    answers = quotes_answers.careful_parsing.discard_quotes
+    assert next(answers) == {('a', ('c',)), ('b', ('d','e',))}
+    answers = quotes_answers.careful_parsing.discard_quotes.by_predicate
+    assert next(answers) == {'a': frozenset({('c',)}), 'b': frozenset({('d', 'e')})}
+    answers = quotes_answers.discard_quotes.by_predicate.first_arg_only
+    assert next(answers) == {'a': frozenset({'c'}), 'b': frozenset({'d'})}
+    answers = quotes_answers.careful_parsing.discard_quotes.by_predicate.first_arg_only.atoms_as_string
+    assert next(answers) == {'a("c")', 'b("d","e")'}
+    # Above assert is not correct and will break if issue #8 is fixed.
+    # assert next(answers) == {'a("c")', 'b("d")'}
+    assert next(answers, None) is None
+
+def test_discard_quotes_complex(complex_quotes_answers):
+    answers = complex_quotes_answers.discard_quotes
+    assert next(answers) == {('a', ('\"cou\"cou\"',)), ('b', ('"&"&"1234""&"',))}
+    assert next(answers, None) is None
 
 def test_multiple_tunning_no_arg(noarg_answers):
     answers = noarg_answers.no_arg
@@ -122,6 +174,8 @@ def test_tunning_atoms_as_string(simple_answers):
 def test_multiple_args_in_atoms(multiple_args):
     answers = multiple_args
     assert next(answers) == {('edge', (4, '"s…lp."')), ('r_e_l', (1, 2))}
+    answers = multiple_args.discard_quotes
+    assert next(answers) == {('edge', (4, 's…lp.')), ('r_e_l', (1, 2))}
     answers = answers.atoms_as_string
     assert next(answers) == {'edge(4,"s…lp.")', 'r_e_l(1,2)'}
     answers.careful_parsing
@@ -133,6 +187,8 @@ def test_multiple_args_in_atoms(multiple_args):
 def test_optimization_access(optimized_answers):
     answers = optimized_answers.with_optimization
     assert next(answers) == ({('edge', (4, '"s…lp."')), ('r_e_l', (1, 2))}, 1)
+    answers = optimized_answers.with_optimization.discard_quotes
+    assert next(answers) == ({('edge', (4, 's…lp.')), ('r_e_l', (1, 2))}, 1)
     answers = answers.no_arg
     assert next(answers) == ({'edge', 'r_e_l'}, 2)
     answers.atoms_as_string

--- a/clyngor/test/test_utils.py
+++ b/clyngor/test/test_utils.py
@@ -46,3 +46,11 @@ def test_file_saving_api_with_as_pyasp(asp_code):
     # must be the same as regular repr of answer sets
     answers = frozenset(ASP(asp_code))
     assert answers == read_answers
+
+
+def test_remove_quotes_argument():
+    example_inputs = ['"\"a\"","b\""', '\\"a\\","b\\"']
+    expected_results = ['"a",b"', '\\"a\\","b\\"']
+
+    for found, expected in zip(map(utils.remove_arguments_quotes,example_inputs), expected_results):
+        assert found == expected

--- a/clyngor/utils.py
+++ b/clyngor/utils.py
@@ -53,6 +53,28 @@ def make_hashable(val):
     return val
 
 
+def remove_quotes_arguments(arguments):
+    """
+    Remove quotes at the beginning and at the end of the argument.
+    >>> remove_quotes_arguments('"a","b"')
+    'a,b'
+    """
+    argument_cleans = []
+    for argument in arguments.split(','):
+        if isinstance(argument,str):
+            if argument[0] == '"' and argument[-1] == '"':
+                argument_clean = argument[1:-1]
+                argument_cleans.append(argument_clean)
+            else:
+                argument_cleans.append(argument)
+        else:
+            argument_cleans.append(argument)
+
+    argument_cleaned_string = ','.join(argument_cleans)
+
+    return argument_cleaned_string
+
+
 def clingo_value_to_python(value:object) -> int or str or tuple:
     """Convert a clingo.Symbol object to the python equivalent"""
     if isinstance(value, (int, str)):

--- a/clyngor/utils.py
+++ b/clyngor/utils.py
@@ -53,26 +53,25 @@ def make_hashable(val):
     return val
 
 
-def remove_quotes_arguments(arguments):
-    """
-    Remove quotes at the beginning and at the end of the argument.
-    >>> remove_quotes_arguments('"a","b"')
+def remove_arguments_quotes(arguments:str):
+    """Remove quotes at the beginning and at the end
+    of the given arguments in ASP format.
+
+    This function is used by the weak parser, and therefore
+    does not need to meet robustness criterion.
+
+    >>> remove_arguments_quotes('a,b')
+    'a,b'
+    >>> remove_arguments_quotes('"a","b"')
+    'a,b'
+    >>> remove_arguments_quotes('"a",b')
     'a,b'
     """
-    argument_cleans = []
-    for argument in arguments.split(','):
-        if isinstance(argument,str):
-            if argument[0] == '"' and argument[-1] == '"':
-                argument_clean = argument[1:-1]
-                argument_cleans.append(argument_clean)
-            else:
-                argument_cleans.append(argument)
-        else:
-            argument_cleans.append(argument)
-
-    argument_cleaned_string = ','.join(argument_cleans)
-
-    return argument_cleaned_string
+    def is_quoted(arg:str) -> bool:
+        return (isinstance(arg, str) and len(arg) >= 2
+                and arg[0] == '"' and arg[-1] == '"' and arg[-2] != '\\')
+    return ','.join(arg[1:-1] if is_quoted(arg) else arg
+                    for arg in arguments.split(','))
 
 
 def clingo_value_to_python(value:object) -> int or str or tuple:


### PR DESCRIPTION
Hello,

Currently, arguments are returned as '"argument"' by clyngor with quotes.

With this option, they are returned as 'argument', which is more easy to handle.