### PR TITLE
Add discard_quotes for as_pyasp.

### DIFF
--- a/clyngor/answers.py
+++ b/clyngor/answers.py
@@ -204,7 +204,7 @@ class Answers:
             if self._group_atoms:
                 return {pred: frozenset() for pred in answer_set}
             if self._as_pyasp:
-                return builder(as_pyasp.Atom(pred, ()) for pred in answer_set)
+                return as_pyasp.TermSet(as_pyasp.Atom(pred, ()) for pred in answer_set)
             return builder(answer_set)
         elif self._first_arg_only:
             answer_set = builder((pred, args[0] if args else ())
@@ -219,9 +219,12 @@ class Answers:
                 if self._as_pyasp:
                     args = as_pyasp.Atom(pred, args)
                 mapping[pred].add(args)
-            return {pred: builder(args) for pred, args in mapping.items()}
+            if self._as_pyasp:
+                return {pred: as_pyasp.TermSet(args) for pred, args in mapping.items()}
+            else:
+                return {pred: builder(args) for pred, args in mapping.items()}
         elif self._as_pyasp:
-            return builder(as_pyasp.Atom(*atom) for atom in answer_set)
+            return as_pyasp.TermSet(as_pyasp.Atom(*atom) for atom in answer_set)
         return answer_set
 
 

--- a/clyngor/answers.py
+++ b/clyngor/answers.py
@@ -154,7 +154,7 @@ class Answers:
             # as_pyasp: remove the quotes for the arguments.
             yield from parsing.Parser(
                 self._collapse_atoms, self._collapse_args,
-                self._discard_quotes and not self._atoms_as_string and not self._as_pyasp,
+                self._discard_quotes and not self._atoms_as_string,
                 self._first_arg_only,
                 parse_integer=self._parse_int
             ).parse_terms(answer_set)
@@ -176,7 +176,7 @@ class Answers:
                 assert args is None or (args.startswith('(') and args.endswith(')'))
                 if args:
                     args = args[1:-1]
-                    if self._discard_quotes and not self._as_pyasp:
+                    if self._discard_quotes:
                         args = utils.remove_arguments_quotes(args)
                     if not self._collapse_atoms:  # else: atom as string
                         # parse also integers, if asked to

--- a/clyngor/as_pyasp.py
+++ b/clyngor/as_pyasp.py
@@ -20,6 +20,12 @@ class Atom:
     def arg(self, n):
         return self.arguments[n]
 
+    def __eq__(self, other_atom)-> bool:
+        return self.predicate == other_atom.predicate and self.arguments == other_atom.arguments
+
+    def __hash__(self):
+        return hash((self.predicate, self.arguments))
+
     def __str__(self):
         if self.nb_args() > 0:
             return '{}({})'.format(self.predicate, ','.join(self.arguments))

--- a/clyngor/as_pyasp.py
+++ b/clyngor/as_pyasp.py
@@ -49,7 +49,7 @@ class TermSet:
     """
 
     def __init__(self, terms:iter=None):
-        self._terms = set(terms)
+        self._terms = frozenset(terms)
 
     def __iter__(self):
         return iter(self._terms)

--- a/clyngor/test/test_answers.py
+++ b/clyngor/test/test_answers.py
@@ -1,7 +1,7 @@
 
 import pytest
 from clyngor.answers import Answers
-
+from clyngor.as_pyasp import Atom, TermSet
 
 @pytest.fixture
 def simple_answers():
@@ -105,6 +105,25 @@ def test_discard_quotes_complex(complex_quotes_answers):
     answers = complex_quotes_answers.discard_quotes
     assert next(answers) == {('a', ('\"cou\"cou\"',)), ('b', ('"&"&"1234""&"',))}
     assert next(answers, None) is None
+
+
+def test_as_pyasp_atom():
+    answers = Answers(('a("b","d")',)).as_pyasp
+    for atom in next(answers):
+        assert atom.__eq__(Atom(predicate='a', args=('"b"','"d"')))
+
+def test_as_pyasp_termset():
+    answers = Answers(('a("b","d")',)).as_pyasp
+    assert next(answers).__eq__(TermSet((Atom(predicate='a',args=('"b"','"d"')),)))
+
+def test_discard_quotes_with_as_pyasp_termset():
+    answers = Answers(('a("b","d")',)).as_pyasp.discard_quotes
+    assert next(answers).__eq__( TermSet((Atom(predicate='a',args=('b','d')),)))
+
+def test_discard_quotes_with_as_pyasp_termset_and_careful_parsing():
+    answers = Answers(('a("b","d")',)).parse_args.as_pyasp.discard_quotes.careful_parsing
+    assert next(answers).__eq__(TermSet((Atom(predicate='a',args=('b','d')),)))
+
 
 def test_multiple_tunning_no_arg(noarg_answers):
     answers = noarg_answers.no_arg

--- a/clyngor/test/test_answers.py
+++ b/clyngor/test/test_answers.py
@@ -1,7 +1,7 @@
 
 import pytest
 from clyngor.answers import Answers
-from clyngor.as_pyasp import Atom
+from clyngor.as_pyasp import Atom, TermSet
 
 @pytest.fixture
 def simple_answers():
@@ -110,19 +110,31 @@ def test_discard_quotes_complex(complex_quotes_answers):
 def test_as_pyasp_atom():
     answers = Answers(('a("b","d")',)).as_pyasp
     for atom in next(answers):
-        assert atom.__eq__(Atom(predicate='a', args=('"b"','"d"')))
+        assert atom == Atom(predicate='a', args=('"b"','"d"'))
 
-def test_as_pyasp_termset():
+def test_as_pyasp_termset_frozenset():
     answers = Answers(('a("b","d")',)).as_pyasp
-    assert next(answers).__eq__(frozenset((Atom(predicate='a',args=('"b"','"d"')),)))
+    assert next(answers) == frozenset((Atom(predicate='a',args=('"b"','"d"')),))
+
+def test_as_pyasp_termset_termset():
+    answers = Answers(('a("b","d")',)).as_pyasp
+    assert next(answers) == TermSet((Atom(predicate='a',args=('"b"','"d"')),))
+
+def test_as_pyasp_termset_string():
+    answers = Answers(('a("b","d")',)).as_pyasp
+    assert str(next(answers)) == 'a("b","d").'
+
+def test_as_pyasp_termset_termset_by_predicate():
+    answers = Answers(('a("b","d")',)).as_pyasp.by_predicate
+    assert next(answers) == {'a': TermSet((Atom(predicate='a',args=('"b"','"d"')),))}
 
 def test_discard_quotes_with_as_pyasp_termset():
     answers = Answers(('a("b","d")',)).as_pyasp.discard_quotes
-    assert next(answers).__eq__(frozenset((Atom(predicate='a',args=('b','d')),)))
+    assert next(answers) == TermSet((Atom(predicate='a',args=('b','d')),))
 
 def test_discard_quotes_with_as_pyasp_termset_and_careful_parsing():
     answers = Answers(('a("b","d")',)).parse_args.as_pyasp.discard_quotes.careful_parsing
-    assert next(answers).__eq__(frozenset((Atom(predicate='a',args=('b','d')),)))
+    assert next(answers) == TermSet((Atom(predicate='a',args=('b','d')),))
 
 
 def test_multiple_tunning_no_arg(noarg_answers):

--- a/clyngor/test/test_answers.py
+++ b/clyngor/test/test_answers.py
@@ -1,7 +1,7 @@
 
 import pytest
 from clyngor.answers import Answers
-from clyngor.as_pyasp import Atom, TermSet
+from clyngor.as_pyasp import Atom
 
 @pytest.fixture
 def simple_answers():
@@ -114,15 +114,15 @@ def test_as_pyasp_atom():
 
 def test_as_pyasp_termset():
     answers = Answers(('a("b","d")',)).as_pyasp
-    assert next(answers).__eq__(TermSet((Atom(predicate='a',args=('"b"','"d"')),)))
+    assert next(answers).__eq__(frozenset((Atom(predicate='a',args=('"b"','"d"')),)))
 
 def test_discard_quotes_with_as_pyasp_termset():
     answers = Answers(('a("b","d")',)).as_pyasp.discard_quotes
-    assert next(answers).__eq__( TermSet((Atom(predicate='a',args=('b','d')),)))
+    assert next(answers).__eq__(frozenset((Atom(predicate='a',args=('b','d')),)))
 
 def test_discard_quotes_with_as_pyasp_termset_and_careful_parsing():
     answers = Answers(('a("b","d")',)).parse_args.as_pyasp.discard_quotes.careful_parsing
-    assert next(answers).__eq__(TermSet((Atom(predicate='a',args=('b','d')),)))
+    assert next(answers).__eq__(frozenset((Atom(predicate='a',args=('b','d')),)))
 
 
 def test_multiple_tunning_no_arg(noarg_answers):


### PR DESCRIPTION
Hello,

during the creation of #9 I thought that as_pyasp and discard_quotes were incompatible. But after looking into as_pyasp behaviour, they seem to be compatible. So I send this pull request to add discard_quotes to as_pyasp and I had some tests for as_pyasp option.