### PR TITLE
Fix int parse error in Answer Set number parsing

### DIFF
--- a/clyngor/parsing.py
+++ b/clyngor/parsing.py
@@ -211,7 +211,8 @@ def parse_clasp_output(output:iter or str, *, yield_stats:bool=False,
     # first answer begins
     while True:
         if line.startswith(ASW_FLAG):
-            yield 'answer_number', int(line[len(ASW_FLAG):])
+            answer_number = line[len(ASW_FLAG):].split(" ")[0]  
+            yield 'answer_number', int(answer_number)
             yield 'answer', next(output)
         elif line.startswith(OPT_FLAG) and yield_opti:
             yield 'optimization', tuple(map(int, line[len(OPT_FLAG):].strip().split()))


### PR DESCRIPTION
In clingo v5.8 (at least), Answer set number is followed by the solving time, for instance

   Answer 1 (Time: 0.577s)

This caused an issue in parsing.py on parsing the answer set number.
This pull request introduces a str split to avoid having (Time ...) in the string representation of the answer set number.
